### PR TITLE
[8] Scoring system and results display

### DIFF
--- a/lib/egot/game_sessions.ex
+++ b/lib/egot/game_sessions.ex
@@ -334,6 +334,13 @@ defmodule Egot.GameSessions do
     Player.create_changeset(player, attrs)
   end
 
+  @doc """
+  Returns the leaderboard (players sorted by score descending) for a game session.
+  """
+  def get_leaderboard(game_session_id) do
+    list_players(game_session_id) |> Enum.sort_by(& &1.score, :desc)
+  end
+
   # -------------------------------------------------------------------
   # Votes
   # -------------------------------------------------------------------
@@ -491,6 +498,10 @@ defmodule Egot.GameSessions do
         winner: winner,
         vote_counts: vote_counts
       })
+
+      # Broadcast updated leaderboard after scores change
+      leaderboard = get_leaderboard(category.game_session_id)
+      broadcast(category.game_session_id, :leaderboard_updated, %{leaderboard: leaderboard})
 
       category
     end)


### PR DESCRIPTION
## Summary

- Add live scoreboard visible during gameplay so players can see rankings in real-time
- Broadcast leaderboard updates after each winner reveal
- Add `get_leaderboard/1` function to GameSessions context

Closes #8

## Changes

### Context (`lib/egot/game_sessions.ex`)
- Add `get_leaderboard/1` function that returns players sorted by score descending
- Broadcast `:leaderboard_updated` event after `reveal_winner/2` updates scores

### Player LiveView (`lib/egot_web/live/player_live/game.ex`)
- Load leaderboard on mount when game is in progress (not just completed)
- Handle `:leaderboard_updated` PubSub event to update scoreboard in real-time
- Add always-visible `live_scoreboard` component showing:
  - Player rankings (1st, 2nd, etc.)
  - Player emails (truncated)
  - Current scores
  - Highlighted row for current player

### Tests
- Add tests for `:leaderboard_updated` broadcast after winner reveal
- Add tests for `get_leaderboard/1` function
- Add LiveView tests for scoreboard display and updates

## Test plan

### Manual testing steps

1. **Start the app**
   ```bash
   mix phx.server
   ```

2. **Set up a game session**
   - Log in as MC and create a new game session
   - Add at least one category with nominees
   - Note the join code

3. **Join as multiple players**
   - Open 2-3 browser tabs/windows in incognito mode
   - Register/log in as different users
   - Join the session using the join code

4. **Verify scoreboard appears during gameplay**
   - As MC, start the game
   - Verify all players see the "Scoreboard" section appear
   - Confirm all player emails are shown with score of 0

5. **Verify scoreboard updates after winner reveal**
   - As MC, open voting for a category
   - Have each player cast a vote
   - Close voting and reveal votes
   - Select a winner and reveal winner
   - Verify players who voted correctly see their score increase
   - Verify all players see the updated leaderboard with correct rankings

6. **Verify current player is highlighted**
   - Each player should see their own row highlighted (bg-primary/20 class)

7. **Verify final leaderboard**
   - Complete all categories and end the game
   - Verify all players see "Final Leaderboard" with correct rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)